### PR TITLE
Fix mqtt config url

### DIFF
--- a/examples/ioTSensorsMQTT-SpB/configs/config.json
+++ b/examples/ioTSensorsMQTT-SpB/configs/config.json
@@ -1,6 +1,6 @@
 {
     "mqtt_config": {
-        "url": "tcp://mqtt:1883",
+        "url": "mqtt://mqtt:1883",
         "qos": 1,
         "client_id": "",
         "user": "",


### PR DESCRIPTION
I am using Sparkplug B example and can't see data streamed to Node RED, turns out the mqtt is set to wrong URL in config.json, this change fixed the problem, I have not check if same error is in other examples